### PR TITLE
baser -> base

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,7 +14,7 @@
     metaler = map (withCategory "metal");
     integrator = map (withCategory "integrations");
     tooler = map (withCategory "tools");
-    baser = map (withCategory "baser");
+    baser = map (withCategory "base");
 
     _file = "github:input-outupt-hk/devshell-capsules";
   in {


### PR DESCRIPTION
`[baser]` shows up in the shell prompt, which is inconsistent