### PR TITLE
add(cloud): htdigest

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -69,6 +69,11 @@
         {package = nixpkgs'.consul;}
         {package = nixpkgs'.nomad;}
         {package = nixpkgs'.sops;}
+        {
+          name = "htdigest";
+          command = ''${nixpkgs'.apacheHttpd}/bin/htdigest "$@"'';
+          help = "create new http authentication tokens";
+        }
         {package = nixpkgs'.skopeo;}
         {
           package = nixpkgs'.writeShellApplication {


### PR DESCRIPTION
This is needed for the interim traefik digest auth solution for providing gated access to particular traefik routes.