### PR TITLE
add module for formatters and linters

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
     metaler = map (withCategory "metal");
     integrator = map (withCategory "integrations");
     tooler = map (withCategory "tools");
+    formatter = map (withCategory "formatters & linters");
     baser = map (withCategory "base");
 
     _file = "github:input-outupt-hk/devshell-capsules";
@@ -144,6 +145,22 @@
           package = nixpkgs'.difftastic;
           name = "difft";
         }
+      ];
+    };
+
+    # --------------------------------------
+    # Tools: common formatting tools
+    # --------------------------------------
+    formatting = {pkgs, ...}: let
+      nixpkgs' = nixpkgs.${pkgs.system};
+    in {
+      inherit _file;
+      commands = formatter [
+        {package = nixpkgs'.treefmt;}
+        {package = nixpkgs'.prettier;}
+        {package = nixpkgs'.shfmt;}
+        {package = nixpkgs'.alejandra;}
+        {package = nixpkgs'.statix;}
       ];
     };
 

--- a/treefmt.toml
+++ b/treefmt.toml
@@ -5,7 +5,7 @@ includes = ["*.nix"]
 
 [formatter.prettier]
 command = "prettier"
-options = ["--plugin", "prettier-plugin-toml", "--write"]
+options = ["--write"]
 includes = [
   "*.css",
   "*.html",
@@ -17,7 +17,6 @@ includes = [
   "*.scss",
   "*.ts",
   "*.yaml",
-  "*.toml",
 ]
 
 [formatter.shell]


### PR DESCRIPTION
Since most of our projects use treefmt, it seems like a bit of an oversight that we don't include it in the devshell, at least optionally.