### PR TITLE
imp: add metal nix 2.14.X for deploy compatibility

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -498,6 +498,22 @@
         "type": "github"
       }
     },
+    "lowdown-src_4": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1633514407,
+        "narHash": "sha256-Dw32tiMjdK9t3ETl5fzGrutQTzh2rufgZV4A/BbxuD4=",
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "rev": "d2c2b44ff6c27b936ec27358a2653caaef8f73b8",
+        "type": "github"
+      },
+      "original": {
+        "owner": "kristapsdz",
+        "repo": "lowdown",
+        "type": "github"
+      }
+    },
     "nix": {
       "inputs": {
         "lowdown-src": "lowdown-src",
@@ -515,6 +531,27 @@
       "original": {
         "owner": "kreisys",
         "ref": "goodnix-maybe-dont-functor",
+        "repo": "nix",
+        "type": "github"
+      }
+    },
+    "nix-deployer": {
+      "inputs": {
+        "lowdown-src": "lowdown-src_4",
+        "nixpkgs": "nixpkgs_13",
+        "nixpkgs-regression": "nixpkgs-regression_3"
+      },
+      "locked": {
+        "lastModified": 1682676126,
+        "narHash": "sha256-CEj8KOj9wN285+c2VWnJhDsSF6OqSvOA9eY/naAuGpQ=",
+        "owner": "NixOS",
+        "repo": "nix",
+        "rev": "4504ee295738a2e7a1cb0a5d9cf94d03e861b5f5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "2.14-maintenance",
         "repo": "nix",
         "type": "github"
       }
@@ -602,6 +639,22 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-regression_3": {
+      "locked": {
+        "lastModified": 1643052045,
+        "narHash": "sha256-uGJ0VXIhWKGXxkeNnq4TvV3CIOkUJ3PAoLZ3HMzNVMw=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "215d4d0fd80ca5163643b03a33fde804a29cc1e2",
+        "type": "github"
+      }
+    },
     "nixpkgs-unstable": {
       "locked": {
         "lastModified": 1646331602,
@@ -668,6 +721,22 @@
     },
     "nixpkgs_13": {
       "locked": {
+        "lastModified": 1670461440,
+        "narHash": "sha256-jy1LB8HOMKGJEGXgzFRLDU1CBGL0/LlkolgnqIsF0D8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "04a75b2eecc0acf6239acf9dd04485ff8d14f425",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-22.11-small",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_14": {
+      "locked": {
         "lastModified": 1684212024,
         "narHash": "sha256-/3ZvkPuIXdyZqPR53qC7aaV5wiwMOY+ddbESOykZ9Vo=",
         "owner": "nixos",
@@ -682,7 +751,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_14": {
+    "nixpkgs_15": {
       "locked": {
         "lastModified": 1644525281,
         "narHash": "sha256-D3VuWLdnLmAXIkooWAtbTGSQI9Fc1lkvAr94wTxhnTU=",
@@ -928,7 +997,7 @@
       "inputs": {
         "agenix": "agenix_3",
         "flake-utils": "flake-utils_4",
-        "nixpkgs": "nixpkgs_14",
+        "nixpkgs": "nixpkgs_15",
         "rust-overlay": "rust-overlay_2"
       },
       "locked": {
@@ -949,7 +1018,8 @@
       "inputs": {
         "bitte": "bitte",
         "iogo": "iogo",
-        "nixpkgs": "nixpkgs_13",
+        "nix-deployer": "nix-deployer",
+        "nixpkgs": "nixpkgs_14",
         "ragenix": "ragenix_2"
       }
     },

--- a/flake.nix
+++ b/flake.nix
@@ -4,6 +4,9 @@
     iogo.url = "github:input-output-hk/bitte-iogo";
     ragenix.url = "github:input-output-hk/ragenix";
     bitte.url = "github:input-output-hk/bitte";
+
+    # Required nix version for current deploy-rs and bitte deploy compat
+    nix-deployer.url = "github:NixOS/nix/2.14-maintenance";
   };
 
   outputs = inputs: let
@@ -80,6 +83,7 @@
       nixpkgs' = nixpkgs.${pkgs.system};
       bitte = inputs.bitte.packages.${pkgs.system}.bitte;
       ragenix = inputs.ragenix.defaultPackage.${pkgs.system};
+      nix-deployer = inputs.nix-deployer.packages.${pkgs.system}.nix;
     in {
       inherit _file;
       commands = metaler [
@@ -88,6 +92,11 @@
         {
           package = nixpkgs'.awscli;
           name = "aws";
+        }
+        {
+          package = nix-deployer;
+          name = "nix";
+          help = "nix 2.14.X for bitte and deploy-rs deploy compatibility";
         }
         {
           package = nixpkgs'.writeShellApplication {


### PR DESCRIPTION
* Provide a compatible version of nix for bitte deploy and deploy-rs metal tooling until those deployer tools are updated to support nix >= 2.15